### PR TITLE
Reveal: allows to sign a reveal

### DIFF
--- a/src/operations.c
+++ b/src/operations.c
@@ -468,6 +468,13 @@ static inline bool parse_byte(uint8_t byte,
                     PARSE_ERROR();
             }
 
+            // If the source is an implicit contract,...
+            if (out->operation.source.originated == 0) {
+                // ... it had better match our key, otherwise why are we signing it?
+                if (COMPARE(&out->operation.source, &out->signing) != 0) PARSE_ERROR();
+            }
+            // OK, it passes muster.
+
             OP_JMPIF(STEP_AFTER_MANAGER_FIELDS,
                      (state->tag == OPERATION_TAG_PROPOSAL || state->tag == OPERATION_TAG_BALLOT));
 
@@ -493,9 +500,6 @@ static inline bool parse_byte(uint8_t byte,
             // We know this is a reveal
 
             // Public key up next! Ensure it matches signing key.
-            // Ignore source :-) and do not parse it from hdr.
-            // We don't much care about reveals, they have very little in the way of bad security
-            // implications and any fees have already been accounted for
             {
                 raw_tezos_header_signature_type_t const *const sig_type =
                     NEXT_TYPE(raw_tezos_header_signature_type_t);
@@ -529,13 +533,6 @@ static inline bool parse_byte(uint8_t byte,
             // This is the one allowable non-reveal operation per set
 
             out->operation.tag = (uint8_t) state->tag;
-
-            // If the source is an implicit contract,...
-            if (out->operation.source.originated == 0) {
-                // ... it had better match our key, otherwise why are we signing it?
-                if (COMPARE(&out->operation.source, &out->signing) != 0) PARSE_ERROR();
-            }
-            // OK, it passes muster.
 
             // This should by default be blanked out
             out->operation.delegate.signature_type = SIGNATURE_TYPE_UNSET;

--- a/test/python/test_instructions.py
+++ b/test/python/test_instructions.py
@@ -668,7 +668,7 @@ def test_sign_delegation_constraints(
         signer_account: Account,
         status_code: StatusCode,
         tezos_navigator: TezosNavigator) -> None:
-    """Test delegation signining constraints."""
+    """Test delegation signing constraints."""
 
     tezos_navigator.setup_app_context(
         setup_account,
@@ -725,6 +725,64 @@ def test_sign_reveal(
         assert reveal_hash == reveal.hash, \
             f"Expected hash {reveal.hash.hex()} but got {reveal_hash.hex()}"
         account.check_signature(signature, bytes(reveal))
+
+
+PARAMETERS_SIGN_REVEAL_CONSTRAINTS = [
+    (
+        DEFAULT_ACCOUNT_2, DEFAULT_ACCOUNT, DEFAULT_ACCOUNT, DEFAULT_ACCOUNT,
+        StatusCode.SECURITY
+    ),
+    (
+        DEFAULT_ACCOUNT, DEFAULT_ACCOUNT_2, DEFAULT_ACCOUNT, DEFAULT_ACCOUNT,
+        # Warning: operation PARSE_ERROR are not available on DEBUG-mode
+        StatusCode.PARSE_ERROR
+    ),
+    (
+        DEFAULT_ACCOUNT, DEFAULT_ACCOUNT, DEFAULT_ACCOUNT_2, DEFAULT_ACCOUNT,
+        StatusCode.SECURITY
+    ),
+    (
+        DEFAULT_ACCOUNT, DEFAULT_ACCOUNT, DEFAULT_ACCOUNT, DEFAULT_ACCOUNT_2,
+        # Warning: operation PARSE_ERROR are not available on DEBUG-mode
+        StatusCode.PARSE_ERROR
+    )
+]
+
+@pytest.mark.parametrize(
+    "setup_account," \
+    "public_key_account," \
+    "source_account," \
+    "signer_account," \
+    "status_code",
+    PARAMETERS_SIGN_REVEAL_CONSTRAINTS
+)
+def test_sign_reveal_constraints(
+        setup_account: Account,
+        public_key_account: Account,
+        source_account: Account,
+        signer_account: Account,
+        status_code: StatusCode,
+        client: TezosClient,
+        tezos_navigator: TezosNavigator) -> None:
+    """Test reveal signing constraints."""
+
+    tezos_navigator.setup_app_context(
+        setup_account,
+        DEFAULT_CHAIN_ID,
+        main_hwm=Hwm(0),
+        test_hwm=Hwm(0)
+    )
+
+    reveal = Reveal(
+        public_key=public_key_account.public_key,
+        source=source_account.public_key_hash,
+    ).forge()
+
+    with status_code.expected():
+        client.sign_message(
+            signer_account,
+            reveal
+        )
 
 
 def test_sign_not_authorized_key(

--- a/test/python/test_instructions.py
+++ b/test/python/test_instructions.py
@@ -727,6 +727,7 @@ def test_sign_reveal(
         account.check_signature(signature, bytes(reveal))
 
 
+# Warning: operation PARSE_ERROR are not available on DEBUG-mode
 PARAMETERS_SIGN_REVEAL_CONSTRAINTS = [
     (
         DEFAULT_ACCOUNT_2, DEFAULT_ACCOUNT, DEFAULT_ACCOUNT, DEFAULT_ACCOUNT,
@@ -734,16 +735,14 @@ PARAMETERS_SIGN_REVEAL_CONSTRAINTS = [
     ),
     (
         DEFAULT_ACCOUNT, DEFAULT_ACCOUNT_2, DEFAULT_ACCOUNT, DEFAULT_ACCOUNT,
-        # Warning: operation PARSE_ERROR are not available on DEBUG-mode
         StatusCode.PARSE_ERROR
     ),
     (
         DEFAULT_ACCOUNT, DEFAULT_ACCOUNT, DEFAULT_ACCOUNT_2, DEFAULT_ACCOUNT,
-        StatusCode.SECURITY
+        StatusCode.PARSE_ERROR
     ),
     (
         DEFAULT_ACCOUNT, DEFAULT_ACCOUNT, DEFAULT_ACCOUNT, DEFAULT_ACCOUNT_2,
-        # Warning: operation PARSE_ERROR are not available on DEBUG-mode
         StatusCode.PARSE_ERROR
     )
 ]
@@ -893,12 +892,12 @@ PARAMETERS_SIGN_MULTIPLE_OPERATIONS = [
     (build_delegation,   build_reveal,           None,              True,  StatusCode.OK         ),
     (build_reveal,       build_delegation,       build_reveal,      True,  StatusCode.OK         ),
 ] + [
-    (build_bad_reveal_1, build_reveal,           None,              False, StatusCode.OK         ),
-    (build_bad_reveal_1, build_delegation,       None,              True,  StatusCode.OK         ),
+    (build_bad_reveal_1, build_reveal,           None,              False, StatusCode.PARSE_ERROR),
+    (build_bad_reveal_1, build_delegation,       None,              True,  StatusCode.PARSE_ERROR),
     (build_bad_reveal_2, build_reveal,           None,              False, StatusCode.PARSE_ERROR),
     (build_bad_reveal_2, build_delegation,       None,              True,  StatusCode.PARSE_ERROR),
-    (build_reveal,       build_bad_reveal_1,     None,              False, StatusCode.SECURITY   ),
-    (build_delegation,   build_bad_reveal_1,     None,              True,  StatusCode.SECURITY   ),
+    (build_reveal,       build_bad_reveal_1,     None,              False, StatusCode.PARSE_ERROR),
+    (build_delegation,   build_bad_reveal_1,     None,              True,  StatusCode.PARSE_ERROR),
     (build_reveal,       build_bad_reveal_2,     None,              False, StatusCode.PARSE_ERROR),
     (build_delegation,   build_bad_reveal_2,     None,              True,  StatusCode.PARSE_ERROR),
     (build_reveal,       build_bad_delegation_1, None,              True,  StatusCode.PARSE_ERROR),

--- a/test/python/utils/client.py
+++ b/test/python/utils/client.py
@@ -162,7 +162,8 @@ class StatusCode(IntEnum):
         """Fail if the right RAPDU code exception is not raise."""
         try:
             yield
-            assert False, f"Expect fail with { self.name } but succeed"
+            assert self == StatusCode.OK, \
+                f"Expect fail with { self.name } but succeed"
         except ExceptionRAPDU as e:
             try:
                 name = f"{StatusCode(e.status).name}"

--- a/test/python/utils/message.py
+++ b/test/python/utils/message.py
@@ -118,6 +118,12 @@ class UnsafeOp:
         raw = watermark + bytes.fromhex(self.operation.forge())
         return RawMessage(raw)
 
+    def merge(self, unsafe_op: 'UnsafeOp') -> 'UnsafeOp':
+        res = self.operation
+        for content in unsafe_op.operation.contents:
+            res = res.operation(content)
+        return UnsafeOp(res)
+
 class Delegation(UnsafeOp):
     """Class representing a delegation."""
 

--- a/test/python/utils/message.py
+++ b/test/python/utils/message.py
@@ -132,6 +132,20 @@ class Delegation(UnsafeOp):
         delegation = ctxt.delegation(delegate, source, counter, fee, gas_limit, storage_limit)
         super().__init__(delegation)
 
+class Reveal(UnsafeOp):
+    """Class representing a reveal."""
+
+    def __init__(self,
+                 public_key: str,
+                 source: str,
+                 counter: int = 0,
+                 fee: int = 0,
+                 gas_limit: int = 0,
+                 storage_limit: int = 0):
+        ctxt = pytezos.using()
+        reveal = ctxt.reveal(public_key, source, counter, fee, gas_limit, storage_limit)
+        super().__init__(reveal)
+
 class Preattestation:
     """Class representing a preattestation."""
 

--- a/test/python/utils/navigator.py
+++ b/test/python/utils/navigator.py
@@ -370,7 +370,7 @@ class TezosNavigator(metaclass=MetaScreen):
                                   account: Account,
                                   delegation: Delegation,
                                   branch: str = DEFAULT_BLOCK_HASH,
-                        navigate: Optional[Callable] = None,
+                                  navigate: Optional[Callable] = None,
                                   **kwargs) -> Tuple[bytes, Signature]:
         """Send a sign and get hash request on delegation and navigate until accept"""
         if navigate is None:


### PR DESCRIPTION
This MR try to fix #11: 
- Split `reveal` and `delegation` cases at `baking_sign_complete`
- Do not check the `destination` for `reveal`
- Do not display for `reveal`
- Check the source for `reveal`
- Add tests that check that signing a `reveal` work
- Add tests that check the constraints of signing a `reveal`
- Add tests that check that at only batches that only operation batches with at most one delegation (not including `reveals`) are authorised to be signed.
