### PR TITLE
Baking: allowing to sign block at reset level

### DIFF
--- a/src/apdu_setup.c
+++ b/src/apdu_setup.c
@@ -30,11 +30,13 @@ static bool ok(void) {
         ram->hwm.main.highest_round = 0;
         ram->hwm.main.had_endorsement = false;
         ram->hwm.main.had_preendorsement = false;
+        ram->hwm.main.had_block = false;
         ram->hwm.main.migrated_to_tenderbake = false;
         ram->hwm.test.highest_level = G.hwm.test;
         ram->hwm.test.highest_round = 0;
         ram->hwm.test.had_endorsement = false;
         ram->hwm.test.had_preendorsement = false;
+        ram->hwm.test.had_block = false;
         ram->hwm.test.migrated_to_tenderbake = false;
     });
 

--- a/src/baking_auth.c
+++ b/src/baking_auth.c
@@ -27,12 +27,15 @@ void write_high_water_mark(parsed_baking_data_t const *const in) {
         if ((in->level > dest->highest_level) || (in->round > dest->highest_round)) {
             dest->had_endorsement = false;
             dest->had_preendorsement = false;
+            dest->had_block = false;
         };
         dest->highest_level = CUSTOM_MAX(in->level, dest->highest_level);
         dest->highest_round = in->round;
         dest->had_endorsement |=
             (in->type == BAKING_TYPE_ENDORSEMENT || in->type == BAKING_TYPE_TENDERBAKE_ENDORSEMENT);
         dest->had_preendorsement |= in->type == BAKING_TYPE_TENDERBAKE_PREENDORSEMENT;
+        dest->had_block |=
+            (in->type == BAKING_TYPE_BLOCK || in->type == BAKING_TYPE_TENDERBAKE_BLOCK);
         dest->migrated_to_tenderbake |= in->is_tenderbake;
     });
 }

--- a/src/baking_auth.c
+++ b/src/baking_auth.c
@@ -76,6 +76,13 @@ static bool is_level_authorized(parsed_baking_data_t const *const baking_info) {
                (baking_info->level == hwm->highest_level &&
                 baking_info->round == hwm->highest_round &&
                 baking_info->type == BAKING_TYPE_TENDERBAKE_PREENDORSEMENT &&
+                !hwm->had_endorsement && !hwm->had_preendorsement) ||
+
+               // It is ok to sign a block if we have not already signed neither an
+               // endorsement nor a preendorsement nor a block for the level/round
+               (baking_info->level == hwm->highest_level &&
+                baking_info->round == hwm->highest_round &&
+                baking_info->type == BAKING_TYPE_TENDERBAKE_BLOCK && !hwm->had_block &&
                 !hwm->had_endorsement && !hwm->had_preendorsement);
 
     } else {

--- a/src/types.h
+++ b/src/types.h
@@ -130,6 +130,7 @@ typedef struct {
     round_t highest_round;
     bool had_endorsement;
     bool had_preendorsement;
+    bool had_block;
     bool migrated_to_tenderbake;
 } high_watermark_t;
 

--- a/test/python/test_instructions.py
+++ b/test/python/test_instructions.py
@@ -512,7 +512,7 @@ def test_sign_block_at_reset_level(client: TezosClient, tezos_navigator: TezosNa
         chain_id=main_chain_id
     )
 
-    with StatusCode.WRONG_VALUES.expected():
+    with StatusCode.OK.expected():
         client.sign_message(account, block)
 
 
@@ -534,10 +534,10 @@ PARAMETERS_SIGN_LEVEL_AUTHORIZED = [
     (build_attestation_dal, (0, 0), build_attestation,     (0, 0), False),
     (build_attestation_dal, (0, 0), build_attestation_dal, (0, 0), False),
     (build_attestation_dal, (0, 0), build_block,           (0, 0), False),
-    (build_block,           (1, 1), build_preattestation,  (1, 1), True ),
-    (build_block,           (1, 1), build_attestation,     (1, 1), True ),
-    (build_block,           (1, 1), build_attestation_dal, (1, 1), True ),
-    (build_block,           (1, 1), build_block,           (1, 1), False),
+    (build_block,           (0, 0), build_preattestation,  (0, 0), True ),
+    (build_block,           (0, 0), build_attestation,     (0, 0), True ),
+    (build_block,           (0, 0), build_attestation_dal, (0, 0), True ),
+    (build_block,           (0, 0), build_block,           (0, 0), False),
 ]
 
 @pytest.mark.parametrize(

--- a/test/python/utils/client.py
+++ b/test/python/utils/client.py
@@ -162,7 +162,8 @@ class StatusCode(IntEnum):
         """Fail if the right RAPDU code exception is not raise."""
         try:
             yield
-            assert False, f"Expect fail with { self.name } but succeed"
+            assert self == StatusCode.OK, \
+                f"Expect fail with { self.name } but succeed"
         except ExceptionRAPDU as e:
             try:
                 name = f"{StatusCode(e.status).name}"


### PR DESCRIPTION
This PR implements the proposal https://github.com/trilitech/ledger-app-tezos-baking/issues/22#issuecomment-1930018673
 - [x] prevent signing a block if another block or an attestation/pre-attestation has already been seen.

