### PR TITLE
Set baking app by default in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ endif
 include $(BOLOS_SDK)/Makefile.defines
 
 ifeq ($(APP),)
-APP=tezos_wallet
+APP=tezos_baking
 endif
 
 ifeq ($(APP),tezos_baking)


### PR DESCRIPTION
# Currently

The [Call Ledger guidelines_enforcer / Dispatch check / Check APP_LOAD_PARAMS](https://github.com/trilitech/ledger-app-tezos-baking/actions/runs/8001842531/job/21853912633?pr=31#logs) do not check the baking app but the wallet app

# Objective

Check the baking app by setting it by default