### PR TITLE
UI: reduce updating time for home screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,16 @@ The latter will require the correct URL for the Ledger device acquired from:
 $ octez-client list connected ledgers
 ```
 
+## How the app works
+
+### High water mark (HWM)
+
+To avoid double baking, double attestation and double pre-attestation, the application maintains a high water mark (HWM) corresponding to the last level/round encountered during signature requests. The HWMs are displayed on the home screen and are updated after each signature.
+
+For performance reasons, the HWM screen is not updated dynamically.
+On Nano devices, press both buttons to update.
+
+
 ## Benchmarking
 The time taken to sign attestations/pre-attestations for baking app can depend on the device used, derivation type etc.
 

--- a/src/apdu_setup.c
+++ b/src/apdu_setup.c
@@ -94,7 +94,7 @@ int handle_deauthorize(void) {
     UPDATE_NVRAM(ram, { memset(&ram->baking_key, 0, sizeof(ram->baking_key)); });
 #ifdef HAVE_BAGL
     // Ignore calculation errors
-    calculate_baking_idle_screens_data();
+    calculate_idle_screen_authorized_key();
     refresh_screens();
 #endif  // HAVE_BAGL
 

--- a/src/apdu_setup.c
+++ b/src/apdu_setup.c
@@ -93,7 +93,9 @@ end:
 int handle_deauthorize(void) {
     UPDATE_NVRAM(ram, { memset(&ram->baking_key, 0, sizeof(ram->baking_key)); });
 #ifdef HAVE_BAGL
-    update_baking_idle_screens();
+    // Ignore calculation errors
+    calculate_baking_idle_screens_data();
+    refresh_screens();
 #endif  // HAVE_BAGL
 
     return io_send_sw(SW_OK);

--- a/src/apdu_sign.c
+++ b/src/apdu_sign.c
@@ -211,7 +211,7 @@ static int baking_sign_complete(bool const send_hash) {
             result = perform_signature(send_hash);
 #ifdef HAVE_BAGL
             // Ignore calculation errors
-            calculate_baking_idle_screens_data();
+            calculate_idle_screen_hwm();
             // The HWM screen is not updated to avoid slowing down the
             // application. Updating the HWM screen may slow down the
             // next signing.

--- a/src/apdu_sign.c
+++ b/src/apdu_sign.c
@@ -210,7 +210,11 @@ static int baking_sign_complete(bool const send_hash) {
             TZ_CHECK(guard_baking_authorized(&G.parsed_baking_data, &global.path_with_curve));
             result = perform_signature(send_hash);
 #ifdef HAVE_BAGL
-            update_baking_idle_screens();
+            // Ignore calculation errors
+            calculate_baking_idle_screens_data();
+            // The HWM screen is not updated to avoid slowing down the
+            // application. Updating the HWM screen may slow down the
+            // next signing.
 #endif
             break;
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -43,10 +43,11 @@ void __attribute__((noreturn)) app_exit(void);
 #ifdef HAVE_BAGL
 
 /**
- * @brief Updates the baking screens
+ * @brief Calculates baking values for the idle screens
  *
+ * @return bool: whether the values have been calculated successfully or not
  */
-void update_baking_idle_screens(void);
+bool calculate_baking_idle_screens_data(void);
 
 /**
  * @brief Prepare confirmation screens callbacks
@@ -74,5 +75,11 @@ extern const ux_flow_step_t ux_prompt_flow_accept_step;
             __VA_ARGS__,                 \
             &ux_prompt_flow_reject_step, \
             &ux_prompt_flow_accept_step)
+
+/**
+ * @brief Refreshes all screens of the current flow
+ *
+ */
+void refresh_screens(void);
 
 #endif  // HAVE_BAGL

--- a/src/ui.h
+++ b/src/ui.h
@@ -43,11 +43,32 @@ void __attribute__((noreturn)) app_exit(void);
 #ifdef HAVE_BAGL
 
 /**
+ * @brief Calculates the chain id for the idle screens
+ *
+ * @return tz_exc: exception, SW_OK if none
+ */
+tz_exc calculate_idle_screen_chain_id(void);
+
+/**
+ * @brief Calculates the authorized key for the idle screens
+ *
+ * @return tz_exc: exception, SW_OK if none
+ */
+tz_exc calculate_idle_screen_authorized_key(void);
+
+/**
+ * @brief Calculates the HWM for the idle screens
+ *
+ * @return tz_exc: exception, SW_OK if none
+ */
+tz_exc calculate_idle_screen_hwm(void);
+
+/**
  * @brief Calculates baking values for the idle screens
  *
- * @return bool: whether the values have been calculated successfully or not
+ * @return tz_exc: exception, SW_OK if none
  */
-bool calculate_baking_idle_screens_data(void);
+tz_exc calculate_baking_idle_screens_data(void);
 
 /**
  * @brief Prepare confirmation screens callbacks

--- a/src/ui_bagl.c
+++ b/src/ui_bagl.c
@@ -38,6 +38,8 @@
 
 #define G_display global.dynamic_display
 
+static void ui_refresh_idle_hwm_screen(void);
+
 /**
  * @brief This structure represents a context needed for home screens navigation
  *
@@ -66,7 +68,10 @@ UX_STEP_NOCB(ux_app_is_ready_step, nn, {"Application", "is ready"});
 UX_STEP_NOCB(ux_version_step, bnnn_paging, {"Tezos Baking", APPVERSION});
 UX_STEP_NOCB(ux_chain_id_step, bnnn_paging, {"Chain", home_context.chain_id});
 UX_STEP_NOCB(ux_authorized_key_step, bnnn_paging, {"Public Key Hash", home_context.authorized_key});
-UX_STEP_NOCB(ux_hwm_step, bnnn_paging, {"High Watermark", home_context.hwm});
+UX_STEP_CB(ux_hwm_step,
+           bnnn_paging,
+           ui_refresh_idle_hwm_screen(),
+           {"High Watermark", home_context.hwm});
 UX_STEP_CB(ux_idle_quit_step, pb, app_exit(), {&C_icon_dashboard_x, "Quit"});
 
 UX_FLOW(ux_idle_flow,
@@ -152,6 +157,16 @@ void ui_initial_screen(void) {
     return;
 end:
     TZ_EXC_PRINT(exc);
+}
+
+/**
+ * @brief Refreshes the idle HWM screen
+ *
+ *        Used to update the HWM by pushing both buttons
+ *
+ */
+static void ui_refresh_idle_hwm_screen(void) {
+    ux_flow_init(0, ux_idle_flow, &ux_hwm_step);
 }
 
 void ux_prepare_confirm_callbacks(ui_callback_t ok_c, ui_callback_t cxl_c) {

--- a/src/ui_bagl.c
+++ b/src/ui_bagl.c
@@ -78,12 +78,7 @@ UX_FLOW(ux_idle_flow,
         &ux_idle_quit_step,
         FLOW_LOOP);
 
-/**
- * @brief Calculates baking values for the idle screens
- *
- * @return bool: whether the values have been calculated successfully or not
- */
-static bool calculate_baking_idle_screens_data(void) {
+bool calculate_baking_idle_screens_data(void) {
     tz_exc exc = SW_OK;
 
     memset(&home_context, 0, sizeof(home_context));
@@ -125,13 +120,6 @@ void ui_initial_screen(void) {
     }
 }
 
-void update_baking_idle_screens(void) {
-    if (calculate_baking_idle_screens_data()) {
-        /// refresh
-        ux_stack_redisplay();
-    }
-}
-
 void ux_prepare_confirm_callbacks(ui_callback_t ok_c, ui_callback_t cxl_c) {
     if (ok_c) {
         G_display.ok_callback = ok_c;
@@ -158,5 +146,9 @@ static void prompt_response(bool const accepted) {
 UX_STEP_CB(ux_prompt_flow_reject_step, pb, prompt_response(false), {&C_icon_crossmark, "Reject"});
 UX_STEP_CB(ux_prompt_flow_accept_step, pb, prompt_response(true), {&C_icon_validate_14, "Accept"});
 UX_STEP_NOCB(ux_eye_step, nn, {"Review", "Request"});
+
+void refresh_screens(void) {
+    ux_stack_redisplay();
+}
 
 #endif  // HAVE_BAGL

--- a/test/test_instructions.py
+++ b/test/test_instructions.py
@@ -522,6 +522,11 @@ def test_sign_preattestation(
 
         tezos_navigator.assert_screen("hwm_before_sign", snap_path=snap_path)
 
+        if firmware.is_nano:
+            # No update for Stax
+            backend.both_click()
+            backend.wait_for_screen_change()
+        tezos_navigator.assert_screen("hwm_after_sign", snap_path=snap_path)
 
     tezos_navigator.check_app_context(
         account,
@@ -574,6 +579,12 @@ def test_sign_attestation(
 
         tezos_navigator.assert_screen("hwm_before_sign", snap_path=snap_path)
 
+        if firmware.is_nano:
+            # No update for Stax
+            backend.both_click()
+            backend.wait_for_screen_change()
+        tezos_navigator.assert_screen("hwm_after_sign", snap_path=snap_path)
+
     tezos_navigator.check_app_context(
         account,
         chain_id=main_chain_id,
@@ -625,6 +636,12 @@ def test_sign_attestation_dal(
 
         tezos_navigator.assert_screen("hwm_before_sign", snap_path=snap_path)
 
+        if firmware.is_nano:
+            # No update for Stax
+            backend.both_click()
+            backend.wait_for_screen_change()
+        tezos_navigator.assert_screen("hwm_after_sign", snap_path=snap_path)
+
     tezos_navigator.check_app_context(
         account,
         chain_id=main_chain_id,
@@ -675,6 +692,12 @@ def test_sign_block(
             account.check_signature(signature, bytes(block))
 
         tezos_navigator.assert_screen("hwm_before_sign", snap_path=snap_path)
+
+        if firmware.is_nano:
+            # No update for Stax
+            backend.both_click()
+            backend.wait_for_screen_change()
+        tezos_navigator.assert_screen("hwm_after_sign", snap_path=snap_path)
 
     tezos_navigator.check_app_context(
         account,

--- a/test/test_instructions.py
+++ b/test/test_instructions.py
@@ -520,13 +520,7 @@ def test_sign_preattestation(
                 f"Expected hash {preattestation.hash.hex()} but got {preattestation_hash.hex()}"
             account.check_signature(signature, bytes(preattestation))
 
-        if firmware.is_nano:
-            # No update for Stax
-            backend.wait_for_screen_change()
-        if firmware.device == "nanos":
-            # Wait blink
-            time.sleep(0.5)
-        tezos_navigator.assert_screen("hwm_after_sign", snap_path=snap_path)
+        tezos_navigator.assert_screen("hwm_before_sign", snap_path=snap_path)
 
 
     tezos_navigator.check_app_context(
@@ -578,13 +572,7 @@ def test_sign_attestation(
                 f"Expected hash {attestation.hash.hex()} but got {attestation_hash.hex()}"
             account.check_signature(signature, bytes(attestation))
 
-        if firmware.is_nano:
-            # No update for Stax
-            backend.wait_for_screen_change()
-        if firmware.device == "nanos":
-            # Wait blink
-            time.sleep(0.5)
-        tezos_navigator.assert_screen("hwm_after_sign", snap_path=snap_path)
+        tezos_navigator.assert_screen("hwm_before_sign", snap_path=snap_path)
 
     tezos_navigator.check_app_context(
         account,
@@ -635,13 +623,7 @@ def test_sign_attestation_dal(
                 f"Expected hash {attestation.hash.hex()} but got {attestation_hash.hex()}"
             account.check_signature(signature, bytes(attestation))
 
-        if firmware.is_nano:
-            # No update for Stax
-            backend.wait_for_screen_change()
-        if firmware.device == "nanos":
-            # Wait blink
-            time.sleep(0.5)
-        tezos_navigator.assert_screen("hwm_after_sign", snap_path=snap_path)
+        tezos_navigator.assert_screen("hwm_before_sign", snap_path=snap_path)
 
     tezos_navigator.check_app_context(
         account,
@@ -692,13 +674,7 @@ def test_sign_block(
                 f"Expected hash {block.hash.hex()} but got {block_hash.hex()}"
             account.check_signature(signature, bytes(block))
 
-        if firmware.is_nano:
-            # No update for Stax
-            backend.wait_for_screen_change()
-        if firmware.device == "nanos":
-            # Wait blink
-            time.sleep(0.5)
-        tezos_navigator.assert_screen("hwm_after_sign", snap_path=snap_path)
+        tezos_navigator.assert_screen("hwm_before_sign", snap_path=snap_path)
 
     tezos_navigator.check_app_context(
         account,


### PR DESCRIPTION
# Context

After a few tests on the weekly test network, we discovered that the signing process was not fast enough.

A comparison of the signing speed was carried out, and commit [Remove custom screensaver. Users can enable custom screensaver from Ledger settings](https://github.com/trilitech/ledger-app-tezos-baking/commit/6117d8deb473a335360b5ceca59cfece4893a83d) clearly had an impact on the signing time:

![all-times](https://github.com/trilitech/ledger-app-tezos-baking/assets/81745561/0a88d631-6445-4803-856e-292bdf59c037)

Among other things, it adds an update to the home screens after each signature, which slows down signature time.

# Suggestion

 - no longer update all the data needed to display the home screens, but only those that are likely to have changed.
 - stop updating the HWM screen at the time of signing
 - update the HWM screen on both click
 
 # Results
 
![all-times-fixed](https://github.com/trilitech/ledger-app-tezos-baking/assets/81745561/5e6f5fa1-2aca-451f-83ad-b7cecaeada9c)
