### PR TITLE
Fix exit without pin code on caller disconnection

### DIFF
--- a/src/ui.h
+++ b/src/ui.h
@@ -38,7 +38,7 @@ void ui_initial_screen(void);
  * @brief Exits the app
  *
  */
-void exit_app(void);
+void __attribute__((noreturn)) app_exit(void);
 
 #ifdef HAVE_BAGL
 

--- a/src/ui_bagl.c
+++ b/src/ui_bagl.c
@@ -67,7 +67,7 @@ UX_STEP_NOCB(ux_version_step, bnnn_paging, {"Tezos Baking", APPVERSION});
 UX_STEP_NOCB(ux_chain_id_step, bnnn_paging, {"Chain", home_context.chain_id});
 UX_STEP_NOCB(ux_authorized_key_step, bnnn_paging, {"Public Key Hash", home_context.authorized_key});
 UX_STEP_NOCB(ux_hwm_step, bnnn_paging, {"High Watermark", home_context.hwm});
-UX_STEP_CB(ux_idle_quit_step, pb, exit_app(), {&C_icon_dashboard_x, "Quit"});
+UX_STEP_CB(ux_idle_quit_step, pb, app_exit(), {&C_icon_dashboard_x, "Quit"});
 
 UX_FLOW(ux_idle_flow,
         &ux_app_is_ready_step,

--- a/src/ui_common.c
+++ b/src/ui_common.c
@@ -30,7 +30,7 @@ static void require_pin(void) {
     os_global_pin_invalidate();
 }
 
-void exit_app(void) {
+void __attribute__((noreturn)) app_exit(void) {
     require_pin();
     os_sched_exit(-1);
 }

--- a/src/ui_nbgl.c
+++ b/src/ui_nbgl.c
@@ -115,7 +115,7 @@ static void ui_menu_about_baking(void) {
 }
 
 void ui_initial_screen(void) {
-    nbgl_useCaseHome("Tezos Baking", &C_tezos, NULL, false, ui_menu_about_baking, exit_app);
+    nbgl_useCaseHome("Tezos Baking", &C_tezos, NULL, false, ui_menu_about_baking, app_exit);
 }
 
 #endif  // HAVE_NBGL


### PR DESCRIPTION
fixes #95 
This PR overrides the `app_exit` function so that Ledger functions that ask to exit the application ask for the pin code first (e.g. if the application `THROWs` exceptions).