### PR TITLE
Use magic byte instead of tag to differentiate between pre-attestation and attestation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ Download the source code for application from github repository [App-tezos-bakin
 ### Building
 
 ```
-$ git clone https://github.com/LedgerHQ/app-tezos.git
-$ cd app-tezos
+$ git clone https://github.com/trilitech/ledger-app-tezos-baking.git
+$ cd ledger-app-tezos-baking
 ```
 Then run the following command to enter into docker container provided by Ledger. You will need to have  docker cli installed.
 Use the docker container `ledger-app-dev-tools` provided by Ledger to build the app.

--- a/src/baking_auth.h
+++ b/src/baking_auth.h
@@ -79,6 +79,7 @@ bool parse_block(buffer_t *buf, parsed_baking_data_t *const out);
  *
  * @param buf: input buffer containing the consensus operation
  * @param out: baking data output
+ * @param is_attestation: whether its an attestation or pre-attestation.
  * @return bool: returns false if it is invalid
  */
-bool parse_consensus_operation(buffer_t *buf, parsed_baking_data_t *const out);
+bool parse_consensus_operation(buffer_t *buf, parsed_baking_data_t *const out, bool is_attestation);

--- a/src/globals.h
+++ b/src/globals.h
@@ -106,7 +106,7 @@ typedef struct {
     blake2b_hash_state_t hash_state;     ///< current blake2b hash state
     uint8_t final_hash[SIGN_HASH_SIZE];  ///< buffer to hold hash of all the message
 
-    uint8_t magic_byte;              ///< current magic byte read
+    magic_byte_t magic_byte;         ///< current magic byte read
     struct parse_state parse_state;  ///< current parser state
 } apdu_sign_state_t;
 

--- a/src/types.h
+++ b/src/types.h
@@ -68,6 +68,17 @@ typedef enum {
     BAKING_TYPE_PREATTESTATION
 } baking_type_t;
 
+/**
+ * @brief magic byte of operations
+ * See: https://tezos.gitlab.io/user/key-management.html#signer-requests
+ */
+typedef enum {
+    MAGIC_BYTE_UNSAFE_OP = 0x03u,       /// magic byte of an operation
+    MAGIC_BYTE_BLOCK = 0x11u,           /// magic byte of a block
+    MAGIC_BYTE_PREATTESTATION = 0x12u,  /// magic byte of a pre-attestation
+    MAGIC_BYTE_ATTESTATION = 0x13u,     /// magic byte of an attestation
+} magic_byte_t;
+
 typedef uint32_t level_t;
 typedef uint32_t round_t;
 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,5 +1,5 @@
 base58
 bip32
 GitPython
-pytezos>=3.11.3
+pytezos==3.11.3
 ragger>=1.18.1


### PR DESCRIPTION
fixes #111
