### PR TITLE
Optimize bls

### DIFF
--- a/src/apdu.c
+++ b/src/apdu.c
@@ -53,21 +53,14 @@ end:
     return exc;
 }
 
-int provide_pubkey(bip32_path_with_curve_t const* const path_with_curve) {
+int provide_pubkey(cx_ecfp_public_key_t const* const pubkey) {
     tz_exc exc = SW_OK;
     cx_err_t error = CX_OK;
 
-    TZ_ASSERT_NOT_NULL(path_with_curve);
+    TZ_ASSERT_NOT_NULL(pubkey);
 
     uint8_t resp[1u + MAX_SIGNATURE_SIZE] = {0};
     size_t offset = 0;
-
-    // Application could be PIN-locked, and pubkey->W_len would then be 0,
-    // so throwing an error rather than returning an empty key
-    TZ_ASSERT(os_global_pin_is_validated() == BOLOS_UX_OK, EXC_SECURITY);
-
-    cx_ecfp_public_key_t* pubkey = (cx_ecfp_public_key_t*) &(tz_ecfp_public_key_t){0};
-    CX_CHECK(generate_public_key(pubkey, path_with_curve));
 
     resp[offset] = pubkey->W_len;
     offset++;

--- a/src/apdu.c
+++ b/src/apdu.c
@@ -33,6 +33,26 @@
 #include <stdint.h>
 #include <string.h>
 
+tz_exc read_path_with_curve(derivation_type_t derivation_type,
+                            buffer_t* buf,
+                            bip32_path_with_curve_t* path_with_curve,
+                            cx_ecfp_public_key_t* pubkey) {
+    tz_exc exc = SW_OK;
+    cx_err_t error = CX_OK;
+
+    TZ_ASSERT_NOT_NULL(buf);
+    TZ_ASSERT_NOT_NULL(path_with_curve);
+    TZ_ASSERT_NOT_NULL(pubkey);
+
+    path_with_curve->derivation_type = derivation_type;
+    TZ_ASSERT(read_bip32_path(buf, &path_with_curve->bip32_path), EXC_WRONG_VALUES);
+    CX_CHECK(generate_public_key(pubkey, path_with_curve));
+
+end:
+    TZ_CONVERT_CX();
+    return exc;
+}
+
 int provide_pubkey(bip32_path_with_curve_t const* const path_with_curve) {
     tz_exc exc = SW_OK;
     cx_err_t error = CX_OK;

--- a/src/apdu.c
+++ b/src/apdu.c
@@ -39,14 +39,21 @@ tz_exc read_path_with_curve(derivation_type_t derivation_type,
                             cx_ecfp_public_key_t* pubkey) {
     tz_exc exc = SW_OK;
     cx_err_t error = CX_OK;
+    bip32_path_with_curve_t tmp_path_with_curve = {0};
 
     TZ_ASSERT_NOT_NULL(buf);
     TZ_ASSERT_NOT_NULL(path_with_curve);
-    TZ_ASSERT_NOT_NULL(pubkey);
 
-    path_with_curve->derivation_type = derivation_type;
-    TZ_ASSERT(read_bip32_path(buf, &path_with_curve->bip32_path), EXC_WRONG_VALUES);
-    CX_CHECK(generate_public_key(pubkey, path_with_curve));
+    tmp_path_with_curve.derivation_type = derivation_type;
+    TZ_ASSERT(read_bip32_path(buf, &tmp_path_with_curve.bip32_path), EXC_WRONG_VALUES);
+
+    // Do not derive the public key if the two path_with_curve are equal
+    if (!bip32_path_with_curve_eq(path_with_curve, &tmp_path_with_curve)) {
+        memmove(path_with_curve, &tmp_path_with_curve, sizeof(bip32_path_with_curve_t));
+        if (pubkey != NULL) {
+            CX_CHECK(generate_public_key(pubkey, path_with_curve));
+        }
+    }
 
 end:
     TZ_CONVERT_CX();

--- a/src/apdu.h
+++ b/src/apdu.h
@@ -88,6 +88,20 @@ static inline int io_send_apdu_err(uint16_t sw) {
 }
 
 /**
+ * @brief Reads a path with curve and derive the public key.
+ *
+ * @param[in]  derivation_type: Derivation type of the key.
+ * @param[in]  buf: Buffer that should contains a bip32 path.
+ * @param[out] path_with_curve: Buffer to store the path with curve.
+ * @param[out] pubkey: Buffer to store the pubkey.
+ * @return tz_exc: exception, SW_OK if none
+ */
+tz_exc read_path_with_curve(derivation_type_t derivation_type,
+                            buffer_t* buf,
+                            bip32_path_with_curve_t* path_with_curve,
+                            cx_ecfp_public_key_t* pubkey);
+
+/**
  * @brief Provides the public key in the apdu response
  *
  *        Expects validated pin

--- a/src/apdu.h
+++ b/src/apdu.h
@@ -109,4 +109,4 @@ tz_exc read_path_with_curve(derivation_type_t derivation_type,
  * @param path_with_curve: bip32 path and curve of the key
  * @return int: zero or positive integer if success, negative integer otherwise.
  */
-int provide_pubkey(bip32_path_with_curve_t const* const path_with_curve);
+int provide_pubkey(cx_ecfp_public_key_t const* const pubkey);

--- a/src/apdu.h
+++ b/src/apdu.h
@@ -89,11 +89,14 @@ static inline int io_send_apdu_err(uint16_t sw) {
 
 /**
  * @brief Reads a path with curve and derive the public key.
+ *        Set [pubkey] to NULL to not deriving the public key.
+ *        Will not derive the public key if the path with curve read
+ *        is the same as the one provided.
  *
- * @param[in]  derivation_type: Derivation type of the key.
- * @param[in]  buf: Buffer that should contains a bip32 path.
- * @param[out] path_with_curve: Buffer to store the path with curve.
- * @param[out] pubkey: Buffer to store the pubkey.
+ * @param[in]     derivation_type: Derivation type of the key.
+ * @param[in]     buf: Buffer that should contains a bip32 path.
+ * @param[in/out] path_with_curve: Buffer to store the path with curve.
+ * @param[out]    pubkey: Buffer to store the pubkey. Can be NULL
  * @return tz_exc: exception, SW_OK if none
  */
 tz_exc read_path_with_curve(derivation_type_t derivation_type,

--- a/src/apdu_hmac.c
+++ b/src/apdu_hmac.c
@@ -66,6 +66,7 @@ static inline tz_exc hmac(uint8_t *const out,
     CX_CHECK(sign(state->signed_hmac_key,
                   &signed_hmac_key_size,
                   path_with_curve,
+                  NULL,
                   key_sha256,
                   sizeof(key_sha256)));
 

--- a/src/apdu_pubkey.c
+++ b/src/apdu_pubkey.c
@@ -69,15 +69,20 @@ int handle_get_public_key(buffer_t *cdata,
                           bool authorize,
                           bool prompt) {
     tz_exc exc = SW_OK;
+    cx_err_t error = CX_OK;
 
     TZ_ASSERT_NOT_NULL(cdata);
 
-    global.path_with_curve.derivation_type = derivation_type;
     if ((cdata->size == 0u) && authorize) {
         TZ_ASSERT(copy_bip32_path_with_curve(&global.path_with_curve, &(g_hwm.baking_key)),
                   EXC_MEMORY_ERROR);
+        CX_CHECK(generate_public_key((cx_ecfp_public_key_t *) &global.public_key,
+                                     &global.path_with_curve));
     } else {
-        TZ_ASSERT(read_bip32_path(cdata, &global.path_with_curve.bip32_path), EXC_WRONG_VALUES);
+        TZ_CHECK(read_path_with_curve(derivation_type,
+                                      cdata,
+                                      &global.path_with_curve,
+                                      (cx_ecfp_public_key_t *) &global.public_key));
     }
 
     TZ_ASSERT(cdata->size == cdata->offset, EXC_WRONG_LENGTH);
@@ -100,5 +105,6 @@ int handle_get_public_key(buffer_t *cdata,
     }
 
 end:
+    TZ_CONVERT_CX();
     return io_send_apdu_err(exc);
 }

--- a/src/apdu_pubkey.c
+++ b/src/apdu_pubkey.c
@@ -74,10 +74,13 @@ int handle_get_public_key(buffer_t *cdata,
     TZ_ASSERT_NOT_NULL(cdata);
 
     if ((cdata->size == 0u) && authorize) {
-        TZ_ASSERT(copy_bip32_path_with_curve(&global.path_with_curve, &(g_hwm.baking_key)),
-                  EXC_MEMORY_ERROR);
-        CX_CHECK(generate_public_key((cx_ecfp_public_key_t *) &global.public_key,
-                                     &global.path_with_curve));
+        // Do not derive the public key if the two path_with_curve are equal
+        if (!bip32_path_with_curve_eq(&global.path_with_curve, &g_hwm.baking_key)) {
+            TZ_ASSERT(copy_bip32_path_with_curve(&global.path_with_curve, &g_hwm.baking_key),
+                      EXC_MEMORY_ERROR);
+            CX_CHECK(generate_public_key((cx_ecfp_public_key_t *) &global.public_key,
+                                         &global.path_with_curve));
+        }
     } else {
         TZ_CHECK(read_path_with_curve(derivation_type,
                                       cdata,

--- a/src/apdu_pubkey.c
+++ b/src/apdu_pubkey.c
@@ -38,7 +38,7 @@
  * @return true
  */
 static bool pubkey_ok(void) {
-    provide_pubkey(&global.path_with_curve);
+    provide_pubkey((cx_ecfp_public_key_t *) &global.public_key);
     return true;
 }
 
@@ -88,7 +88,7 @@ int handle_get_public_key(buffer_t *cdata,
     TZ_ASSERT(cdata->size == cdata->offset, EXC_WRONG_LENGTH);
 
     if (!prompt) {
-        return provide_pubkey(&global.path_with_curve);
+        return provide_pubkey((cx_ecfp_public_key_t *) &global.public_key);
     } else {
         // INS_PROMPT_PUBLIC_KEY || INS_AUTHORIZE_BAKING
         ui_callback_t cb;

--- a/src/apdu_setup.c
+++ b/src/apdu_setup.c
@@ -55,7 +55,7 @@ static bool ok(void) {
 
     UPDATE_NVRAM;
 
-    provide_pubkey(&global.path_with_curve);
+    provide_pubkey((cx_ecfp_public_key_t *) &global.public_key);
 
     return true;
 }

--- a/src/apdu_setup.c
+++ b/src/apdu_setup.c
@@ -72,13 +72,15 @@ int handle_setup(buffer_t *cdata, derivation_type_t derivation_type) {
 
     TZ_ASSERT_NOT_NULL(cdata);
 
-    global.path_with_curve.derivation_type = derivation_type;
-
     TZ_ASSERT(buffer_read_u32(cdata, &G.main_chain_id.v, BE) &&  // chain id
                   buffer_read_u32(cdata, &G.hwm.main, BE) &&     // main hwm level
-                  buffer_read_u32(cdata, &G.hwm.test, BE) &&     // test hwm level
-                  read_bip32_path(cdata, &global.path_with_curve.bip32_path),
+                  buffer_read_u32(cdata, &G.hwm.test, BE),       // test hwm level
               EXC_WRONG_VALUES);
+
+    TZ_CHECK(read_path_with_curve(derivation_type,
+                                  cdata,
+                                  &global.path_with_curve,
+                                  (cx_ecfp_public_key_t *) &global.public_key));
 
     TZ_ASSERT(cdata->size == cdata->offset, EXC_WRONG_LENGTH);
 

--- a/src/apdu_sign.c
+++ b/src/apdu_sign.c
@@ -311,7 +311,12 @@ static int perform_signature(bool const send_hash) {
 
     size_t signature_size = MAX_SIGNATURE_SIZE;
 
-    CX_CHECK(sign(resp + offset, &signature_size, &global.path_with_curve, message, message_len));
+    CX_CHECK(sign(resp + offset,
+                  &signature_size,
+                  &global.path_with_curve,
+                  (cx_ecfp_public_key_t *) &global.public_key,
+                  message,
+                  message_len));
 
     offset += signature_size;
 

--- a/src/apdu_sign.c
+++ b/src/apdu_sign.c
@@ -215,7 +215,9 @@ int handle_sign(buffer_t *cdata, const bool last, const bool with_hash) {
             break;
         case MAGIC_BYTE_UNSAFE_OP:
             // Parse the operation. It will be verified in `baking_sign_complete`.
-            TZ_CHECK(parse_operations(cdata, &G.maybe_ops.v, &global.path_with_curve));
+            TZ_CHECK(parse_operations(cdata,
+                                      &G.maybe_ops.v,
+                                      (cx_ecfp_public_key_t *) &global.public_key));
             break;
         default:
             TZ_FAIL(EXC_PARSE_ERROR);

--- a/src/apdu_sign.c
+++ b/src/apdu_sign.c
@@ -161,11 +161,12 @@ int select_signing_key(buffer_t *cdata, derivation_type_t derivation_type) {
 
     clear_data();
 
-    TZ_ASSERT(read_bip32_path(cdata, &global.path_with_curve.bip32_path), EXC_WRONG_VALUES);
+    TZ_CHECK(read_path_with_curve(derivation_type,
+                                  cdata,
+                                  &global.path_with_curve,
+                                  (cx_ecfp_public_key_t *) &global.public_key));
 
     TZ_ASSERT(cdata->size == cdata->offset, EXC_WRONG_LENGTH);
-
-    global.path_with_curve.derivation_type = derivation_type;
 
     return io_send_sw(SW_OK);
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -58,6 +58,9 @@ WARN_UNUSED_RESULT cx_err_t bip32_derive_get_pubkey_bls(const uint32_t *path,
  *
  * @param[in]  path_len        Bip32 path length.
  *
+ * @param[in]  public_key      Must be the BLS key associated with the path and the inner seed.
+ *                             If NULL, it will be computed using the path and the inner seed.
+ *
  * @param[in]  msg             Digest of the message to be signed.
  *                             The length of *message* must be shorter than the group order size.
  *                             Otherwise it is truncated.
@@ -73,10 +76,12 @@ WARN_UNUSED_RESULT cx_err_t bip32_derive_get_pubkey_bls(const uint32_t *path,
  *                             - CX_EC_INVALID_CURVE
  *                             - CX_INTERNAL_ERROR
  */
-WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_bls_sign_hash(const uint32_t *path,
-                                                                 size_t path_len,
-                                                                 uint8_t const *msg,
-                                                                 size_t msg_len,
-                                                                 uint8_t *sig,
-                                                                 size_t *sig_len);
+WARN_UNUSED_RESULT cx_err_t
+bip32_derive_with_seed_bls_sign_hash(const uint32_t *path,
+                                     size_t path_len,
+                                     cx_ecfp_384_public_key_t *public_key,
+                                     uint8_t const *msg,
+                                     size_t msg_len,
+                                     uint8_t *sig,
+                                     size_t *sig_len);
 #endif

--- a/src/globals.h
+++ b/src/globals.h
@@ -123,6 +123,7 @@ typedef struct {
     } dynamic_display;
 
     bip32_path_with_curve_t path_with_curve;  ///< holds the bip32 path and curve of the current key
+    tz_ecfp_public_key_t public_key;          ///< holds the current public key
 
     /// apdu handling state
     struct {

--- a/src/keys.c
+++ b/src/keys.c
@@ -165,8 +165,12 @@ end:
 cx_err_t sign(uint8_t *const out,
               size_t *out_size,
               bip32_path_with_curve_t const *const path_with_curve,
+              cx_ecfp_public_key_t *public_key,
               uint8_t const *const in,
               size_t const in_size) {
+#ifdef TARGET_NANOS
+    UNUSED(public_key);
+#endif
     if ((out == NULL) || (out_size == NULL) || (path_with_curve == NULL) || (in == NULL)) {
         return CX_INVALID_PARAMETER;
     }
@@ -219,6 +223,7 @@ cx_err_t sign(uint8_t *const out,
         case DERIVATION_TYPE_BLS12_381: {
             CX_CHECK(bip32_derive_with_seed_bls_sign_hash(bip32_path->components,
                                                           bip32_path->length,
+                                                          (cx_ecfp_384_public_key_t *) public_key,
                                                           (uint8_t const *) PIC(in),
                                                           in_size,
                                                           out,

--- a/src/keys.c
+++ b/src/keys.c
@@ -100,24 +100,10 @@ end:
     return error;
 }
 
-/**
- * @brief Extract the public key hash from a public key and a curve
- *
- *        Is non-reentrant
- *
- * @param hash_out: public key hash output
- * @param hash_out_size: output size
- * @param compressed_out: compressed public key output
- *                        pass NULL if this value is not desired
- * @param derivation_type: curve
- * @param param public_key: public key
- * @return cx_err_t: error, CX_OK if none
- */
-static cx_err_t public_key_hash(uint8_t *const hash_out,
-                                size_t const hash_out_size,
-                                cx_ecfp_compressed_public_key_t *compressed_out,
-                                derivation_type_t const derivation_type,
-                                cx_ecfp_public_key_t const *const public_key) {
+cx_err_t public_key_hash(uint8_t *const hash_out,
+                         size_t const hash_out_size,
+                         cx_ecfp_compressed_public_key_t *compressed_out,
+                         cx_ecfp_public_key_t const *const public_key) {
     if ((hash_out == NULL) || (public_key == NULL)) {
         return CX_INVALID_PARAMETER;
     }
@@ -129,16 +115,15 @@ static cx_err_t public_key_hash(uint8_t *const hash_out,
     cx_ecfp_compressed_public_key_t *compressed =
         (cx_ecfp_compressed_public_key_t *) &(tz_ecfp_compressed_public_key_t){0};
 
-    switch (derivation_type) {
-        case DERIVATION_TYPE_ED25519:
-        case DERIVATION_TYPE_BIP32_ED25519: {
+    switch (public_key->curve) {
+        case CX_CURVE_Ed25519: {
             compressed->curve = public_key->curve;
             compressed->W_len = TZ_EDPK_LEN;
             memcpy(compressed->W, public_key->W + 1, compressed->W_len);
             break;
         }
-        case DERIVATION_TYPE_SECP256K1:
-        case DERIVATION_TYPE_SECP256R1: {
+        case CX_CURVE_SECP256K1:
+        case CX_CURVE_SECP256R1: {
             compressed->curve = public_key->curve;
             compressed->W_len = COMPRESSED_PK_LEN;
             memcpy(compressed->W, public_key->W, compressed->W_len);
@@ -146,7 +131,7 @@ static cx_err_t public_key_hash(uint8_t *const hash_out,
             break;
         }
 #ifndef TARGET_NANOS
-        case DERIVATION_TYPE_BLS12_381: {
+        case CX_CURVE_BLS12_381_G1: {
             compressed->curve = public_key->curve;
             compressed->W_len = BLS_COMPRESSED_PK_LEN;
             memcpy(compressed->W, public_key->W + 1, compressed->W_len);
@@ -172,29 +157,6 @@ static cx_err_t public_key_hash(uint8_t *const hash_out,
     if (compressed_out != NULL) {
         memmove(compressed_out, compressed, sizeof(tz_ecfp_compressed_public_key_t));
     }
-
-end:
-    return error;
-}
-
-cx_err_t generate_public_key_hash(uint8_t *const hash_out,
-                                  size_t const hash_out_size,
-                                  cx_ecfp_compressed_public_key_t *compressed_out,
-                                  bip32_path_with_curve_t const *const path_with_curve) {
-    if ((hash_out == NULL) || (path_with_curve == NULL)) {
-        return CX_INVALID_PARAMETER;
-    }
-
-    cx_ecfp_public_key_t *pubkey = (cx_ecfp_public_key_t *) &(tz_ecfp_public_key_t){0};
-    cx_err_t error = CX_OK;
-
-    CX_CHECK(generate_public_key(pubkey, path_with_curve));
-
-    CX_CHECK(public_key_hash(hash_out,
-                             hash_out_size,
-                             compressed_out,
-                             path_with_curve->derivation_type,
-                             pubkey));
 
 end:
     return error;

--- a/src/keys.h
+++ b/src/keys.h
@@ -76,23 +76,22 @@ typedef enum {
     (((signature_type_t) 0 <= type) && (type < SIGNATURE_TYPE_UNSET))
 
 /**
- * @brief Converts `derivation_type` to `signature_type`
+ * @brief Gets the signature_type of a public_key
  *
- * @param derivation_type: derivation_type
+ * @param public_key: public key
  * @return signature_type_t: signature_type result
  */
-static inline signature_type_t derivation_type_to_signature_type(
-    derivation_type_t const derivation_type) {
-    switch (derivation_type) {
-        case DERIVATION_TYPE_SECP256K1:
+static inline signature_type_t signature_type_of_public_key(
+    cx_ecfp_public_key_t const *const public_key) {
+    switch (public_key->curve) {
+        case CX_CURVE_SECP256K1:
             return SIGNATURE_TYPE_SECP256K1;
-        case DERIVATION_TYPE_SECP256R1:
+        case CX_CURVE_SECP256R1:
             return SIGNATURE_TYPE_SECP256R1;
-        case DERIVATION_TYPE_ED25519:
-        case DERIVATION_TYPE_BIP32_ED25519:
+        case CX_CURVE_Ed25519:
             return SIGNATURE_TYPE_ED25519;
 #ifndef TARGET_NANOS
-        case DERIVATION_TYPE_BLS12_381:
+        case CX_CURVE_BLS12_381_G1:
             return SIGNATURE_TYPE_BLS12_381;
 #endif
         default:
@@ -266,19 +265,21 @@ cx_err_t generate_public_key(cx_ecfp_public_key_t *public_key,
                              bip32_path_with_curve_t const *const path_with_curve);
 
 /**
- * @brief Generates a public key hash from a bip32 path and a curve
+ * @brief Extract the public key hash from a public key and a curve
+ *
+ *        Is non-reentrant
  *
  * @param hash_out: public key hash output
  * @param hash_out_size: output size
  * @param compressed_out: compressed public key output
  *                        pass NULL if this value is not desired
- * @param path_with_curve: bip32 path and curve
+ * @param public_key: public key
  * @return cx_err_t: error, CX_OK if none
  */
-cx_err_t generate_public_key_hash(uint8_t *const hash_out,
-                                  size_t const hash_out_size,
-                                  cx_ecfp_compressed_public_key_t *const compressed_out,
-                                  bip32_path_with_curve_t const *const path_with_curve);
+cx_err_t public_key_hash(uint8_t *const hash_out,
+                         size_t const hash_out_size,
+                         cx_ecfp_compressed_public_key_t *compressed_out,
+                         cx_ecfp_public_key_t const *const public_key);
 
 /**
  * @brief Signs a message with a key

--- a/src/keys.h
+++ b/src/keys.h
@@ -289,6 +289,9 @@ cx_err_t public_key_hash(uint8_t *const hash_out,
  * @param out: signature output
  * @param out_size: output size
  * @param path_with_curve: bip32 path and curve of the key
+ * @param public_key: BLS public key associated with the path and the inner seed.
+ *                    Will be used only for BLS signature.
+ *                    If NULL, it will be computed using the path and the inner seed.
  * @param in: message input
  * @param in_size: input size
  * @return cx_err_t: error, CX_OK if none
@@ -296,5 +299,6 @@ cx_err_t public_key_hash(uint8_t *const hash_out,
 cx_err_t sign(uint8_t *const out,
               size_t *out_size,
               bip32_path_with_curve_t const *const path_with_curve,
+              cx_ecfp_public_key_t *public_key,
               uint8_t const *const in,
               size_t const in_size);

--- a/src/operations.h
+++ b/src/operations.h
@@ -145,17 +145,16 @@ struct parse_state {
  *        operation of any other type, which is the one it puts into
  *        the group.
  *
- *        Some checks are carried out during the parsing using a key using a key
+ *        Some checks are carried out during the parsing using a key
  *
  * @param buf: input operation
  * @param out: parsing output
- * @param curve: curve of the key
- * @param path_with_curve: bip32 path and curve of the key
+ * @param public_key: public key
  * @return tz_exc: exception, SW_OK if none
  */
 tz_exc parse_operations(buffer_t *buf,
                         struct parsed_operation_group *const out,
-                        bip32_path_with_curve_t const *const path_with_curve);
+                        cx_ecfp_public_key_t const *const public_key);
 
 /**
  * @brief Checks parsing has been completed successfully

--- a/src/to_string.c
+++ b/src/to_string.c
@@ -36,22 +36,19 @@ static int pkh_to_string(char *const dest,
                          signature_type_t const signature_type,
                          uint8_t const hash[KEY_HASH_SIZE]);
 
-tz_exc bip32_path_with_curve_to_pkh_string(char *const out,
-                                           size_t const out_size,
-                                           bip32_path_with_curve_t const *const key) {
+tz_exc pk_to_pkh_string(char *const out,
+                        size_t const out_size,
+                        cx_ecfp_public_key_t const *const public_key) {
     tz_exc exc = SW_OK;
     cx_err_t error = CX_OK;
     uint8_t hash[KEY_HASH_SIZE];
 
     TZ_ASSERT_NOT_NULL(out);
-    TZ_ASSERT_NOT_NULL(key);
+    TZ_ASSERT_NOT_NULL(public_key);
 
-    CX_CHECK(generate_public_key_hash(hash, sizeof(hash), NULL, key));
+    CX_CHECK(public_key_hash(hash, sizeof(hash), NULL, public_key));
 
-    TZ_ASSERT(pkh_to_string(out,
-                            out_size,
-                            derivation_type_to_signature_type(key->derivation_type),
-                            hash) >= 0,
+    TZ_ASSERT(pkh_to_string(out, out_size, signature_type_of_public_key(public_key), hash) >= 0,
               EXC_WRONG_LENGTH);
 
 end:

--- a/src/to_string.h
+++ b/src/to_string.h
@@ -33,16 +33,16 @@
 #define TICKER_WITH_SPACE " XTZ"
 
 /**
- * @brief Converts a key to a public key hash string using its bip32 path and curve
+ * @brief Converts a key to a public key hash string using its public key
  *
  * @param out: result output
  * @param out_size: output size
- * @param key: bip32 path and curve of the key
+ * @param public_key: public key
  * @return tz_exc: exception, SW_OK if none
  */
-tz_exc bip32_path_with_curve_to_pkh_string(char *const out,
-                                           size_t const out_size,
-                                           bip32_path_with_curve_t const *const key);
+tz_exc pk_to_pkh_string(char *const out,
+                        size_t const out_size,
+                        cx_ecfp_public_key_t const *const public_key);
 
 /**
  * @brief Converts a chain id to string

--- a/src/ui_bagl.c
+++ b/src/ui_bagl.c
@@ -224,7 +224,13 @@ tz_exc calculate_idle_screen_authorized_key(void) {
                               "No Key Authorized"),
                   EXC_WRONG_LENGTH);
     } else {
-        CX_CHECK(generate_public_key(authorized_pk, &g_hwm.baking_key));
+        // Do not derive the public key if the two path_with_curve are equal
+        if (!bip32_path_with_curve_eq(&global.path_with_curve, &g_hwm.baking_key)) {
+            CX_CHECK(generate_public_key((cx_ecfp_public_key_t *) authorized_pk,
+                                         &global.path_with_curve));
+        } else {
+            memmove(authorized_pk, &global.public_key, sizeof(tz_ecfp_public_key_t));
+        }
 
         TZ_CHECK(pk_to_pkh_string(home_context.authorized_key,
                                   sizeof(home_context.authorized_key),

--- a/src/ui_bagl.c
+++ b/src/ui_bagl.c
@@ -212,6 +212,9 @@ end:
 
 tz_exc calculate_idle_screen_authorized_key(void) {
     tz_exc exc = SW_OK;
+    cx_err_t error = CX_OK;
+
+    cx_ecfp_public_key_t *authorized_pk = (cx_ecfp_public_key_t *) &(tz_ecfp_public_key_t){0};
 
     memset(&home_context.authorized_key, 0, sizeof(home_context.authorized_key));
 
@@ -221,12 +224,15 @@ tz_exc calculate_idle_screen_authorized_key(void) {
                               "No Key Authorized"),
                   EXC_WRONG_LENGTH);
     } else {
-        TZ_CHECK(bip32_path_with_curve_to_pkh_string(home_context.authorized_key,
-                                                     sizeof(home_context.authorized_key),
-                                                     &g_hwm.baking_key));
+        CX_CHECK(generate_public_key(authorized_pk, &g_hwm.baking_key));
+
+        TZ_CHECK(pk_to_pkh_string(home_context.authorized_key,
+                                  sizeof(home_context.authorized_key),
+                                  authorized_pk));
     }
 
 end:
+    TZ_CONVERT_CX();
     return exc;
 }
 

--- a/src/ui_delegation_bagl.c
+++ b/src/ui_delegation_bagl.c
@@ -61,9 +61,9 @@ int prompt_delegation(ui_callback_t const ok_cb, ui_callback_t const cxl_cb) {
 
     memset(&delegation_context, 0, sizeof(delegation_context));
 
-    TZ_CHECK(bip32_path_with_curve_to_pkh_string(delegation_context.address,
-                                                 sizeof(delegation_context.address),
-                                                 &global.path_with_curve));
+    TZ_CHECK(pk_to_pkh_string(delegation_context.address,
+                              sizeof(delegation_context.address),
+                              (cx_ecfp_public_key_t *) &global.public_key));
 
     TZ_ASSERT(microtez_to_string(delegation_context.fee,
                                  sizeof(delegation_context.fee),

--- a/src/ui_delegation_nbgl.c
+++ b/src/ui_delegation_nbgl.c
@@ -85,9 +85,9 @@ int prompt_delegation(ui_callback_t const ok_cb, ui_callback_t const cxl_cb) {
     delegation_context.ok_cb = ok_cb;
     delegation_context.cxl_cb = cxl_cb;
 
-    TZ_CHECK(bip32_path_with_curve_to_pkh_string(delegation_context.tagValueRef[ADDRESS_IDX],
-                                                 MAX_LENGTH,
-                                                 &global.path_with_curve));
+    TZ_CHECK(pk_to_pkh_string(delegation_context.tagValueRef[ADDRESS_IDX],
+                              MAX_LENGTH,
+                              (cx_ecfp_public_key_t *) &global.public_key));
 
     TZ_ASSERT(microtez_to_string(delegation_context.tagValueRef[FEE_IDX],
                                  MAX_LENGTH,

--- a/src/ui_nbgl.c
+++ b/src/ui_nbgl.c
@@ -85,7 +85,13 @@ static void initInfo(void) {
         TZ_ASSERT(copy_string(infoContentsBridge[PKH_IDX], MAX_LENGTH, "No Key Authorized"),
                   EXC_WRONG_LENGTH);
     } else {
-        CX_CHECK(generate_public_key(authorized_pk, &g_hwm.baking_key));
+        // Do not derive the public key if the two path_with_curve are equal
+        if (!bip32_path_with_curve_eq(&global.path_with_curve, &g_hwm.baking_key)) {
+            CX_CHECK(generate_public_key((cx_ecfp_public_key_t*) authorized_pk,
+                                         &global.path_with_curve));
+        } else {
+            memmove(authorized_pk, &global.public_key, sizeof(tz_ecfp_public_key_t));
+        }
 
         TZ_CHECK(pk_to_pkh_string(infoContentsBridge[PKH_IDX], MAX_LENGTH, authorized_pk));
     }

--- a/src/ui_nbgl.c
+++ b/src/ui_nbgl.c
@@ -68,6 +68,9 @@ static const nbgl_contentInfoList_t infoList = {.nbInfos = INFO_NB,
  */
 static void initInfo(void) {
     tz_exc exc = SW_OK;
+    cx_err_t error = CX_OK;
+
+    cx_ecfp_public_key_t* authorized_pk = (cx_ecfp_public_key_t*) &(tz_ecfp_public_key_t){0};
 
     for (tz_infoIndex_t idx = 0; idx < INFO_NB; idx++) {
         infoContents[idx] = infoContentsBridge[idx];
@@ -82,9 +85,9 @@ static void initInfo(void) {
         TZ_ASSERT(copy_string(infoContentsBridge[PKH_IDX], MAX_LENGTH, "No Key Authorized"),
                   EXC_WRONG_LENGTH);
     } else {
-        TZ_CHECK(bip32_path_with_curve_to_pkh_string(infoContentsBridge[PKH_IDX],
-                                                     MAX_LENGTH,
-                                                     &g_hwm.baking_key));
+        CX_CHECK(generate_public_key(authorized_pk, &g_hwm.baking_key));
+
+        TZ_CHECK(pk_to_pkh_string(infoContentsBridge[PKH_IDX], MAX_LENGTH, authorized_pk));
     }
 
     TZ_ASSERT(hwm_to_string(infoContentsBridge[HWM_IDX], MAX_LENGTH, &g_hwm.hwm.main) >= 0,
@@ -105,6 +108,7 @@ static void initInfo(void) {
         EXC_WRONG_LENGTH);
 
 end:
+    TZ_CONVERT_CX();
     TZ_EXC_PRINT(exc);
 }
 

--- a/src/ui_pubkey_bagl.c
+++ b/src/ui_pubkey_bagl.c
@@ -58,9 +58,9 @@ int prompt_pubkey(bool authorize, ui_callback_t ok_cb, ui_callback_t cxl_cb) {
 
     memset(&address_context, 0, sizeof(address_context));
 
-    TZ_CHECK(bip32_path_with_curve_to_pkh_string(address_context.public_key_hash,
-                                                 sizeof(address_context.public_key_hash),
-                                                 &global.path_with_curve));
+    TZ_CHECK(pk_to_pkh_string(address_context.public_key_hash,
+                              sizeof(address_context.public_key_hash),
+                              (cx_ecfp_public_key_t *) &global.public_key));
 
     ux_prepare_confirm_callbacks(ok_cb, cxl_cb);
     if (authorize) {

--- a/src/ui_pubkey_nbgl.c
+++ b/src/ui_pubkey_nbgl.c
@@ -69,9 +69,9 @@ int prompt_pubkey(bool authorize, ui_callback_t ok_cb, ui_callback_t cxl_cb) {
     address_context.ok_cb = ok_cb;
     address_context.cxl_cb = cxl_cb;
 
-    TZ_CHECK(bip32_path_with_curve_to_pkh_string(address_context.buffer,
-                                                 sizeof(address_context.buffer),
-                                                 &global.path_with_curve));
+    TZ_CHECK(pk_to_pkh_string(address_context.buffer,
+                              sizeof(address_context.buffer),
+                              (cx_ecfp_public_key_t*) &global.public_key));
 
     const char* text;
     if (authorize) {

--- a/src/ui_setup_bagl.c
+++ b/src/ui_setup_bagl.c
@@ -67,9 +67,9 @@ int prompt_setup(ui_callback_t const ok_cb, ui_callback_t const cxl_cb) {
 
     memset(&setup_context, 0, sizeof(setup_context));
 
-    TZ_CHECK(bip32_path_with_curve_to_pkh_string(setup_context.address,
-                                                 sizeof(setup_context.address),
-                                                 &global.path_with_curve));
+    TZ_CHECK(pk_to_pkh_string(setup_context.address,
+                              sizeof(setup_context.address),
+                              (cx_ecfp_public_key_t *) &global.public_key));
 
     TZ_ASSERT(chain_id_to_string_with_aliases(setup_context.chain,
                                               sizeof(setup_context.chain),

--- a/src/ui_setup_nbgl.c
+++ b/src/ui_setup_nbgl.c
@@ -146,9 +146,9 @@ int prompt_setup(ui_callback_t const ok_cb, ui_callback_t const cxl_cb) {
     setup_context.ok_cb = ok_cb;
     setup_context.cxl_cb = cxl_cb;
 
-    TZ_CHECK(bip32_path_with_curve_to_pkh_string(setup_context.tagValueRef[ADDRESS_IDX],
-                                                 MAX_LENGTH,
-                                                 &global.path_with_curve));
+    TZ_CHECK(pk_to_pkh_string(setup_context.tagValueRef[ADDRESS_IDX],
+                              MAX_LENGTH,
+                              (cx_ecfp_public_key_t *) &global.public_key));
 
     TZ_ASSERT(chain_id_to_string_with_aliases(setup_context.tagValueRef[CHAIN_IDX],
                                               MAX_LENGTH,


### PR DESCRIPTION
This PR add optimization to BLS signing.

 - Stop hashing if the hash is not required.
 - Store the public key and use it in the signature (instead of derivates it again)