### PR TITLE
Bump tezos version to Seoul

### DIFF
--- a/src/operations.h
+++ b/src/operations.h
@@ -32,6 +32,14 @@
 #include "types.h"
 
 /**
+ * @brief Standard 4 bytes size
+ *
+ */
+typedef struct {
+    uint8_t value[4];  ///< value of the size
+} __attribute__((packed)) raw_size;
+
+/**
  * @brief Wire format that gets parsed into `signature_type`
  *
  */
@@ -69,6 +77,16 @@ union public_key {
 #endif
 } __attribute__((packed));
 
+#ifndef TARGET_NANOS
+/**
+ * @brief Wire representation of bls signature
+ *
+ */
+struct bls_signature {
+    uint8_t value[96];  ///< raw BLS signature
+} __attribute__((packed));
+#endif
+
 /**
  * @brief Wire representation of delegation
  *
@@ -103,6 +121,8 @@ struct nexttype_subparser_state {
 
     /// union of all wire structure
     union {
+        raw_size size;  ///< wire size
+
         raw_tezos_header_signature_type_t sigtype;  ///< wire signature_type
 
         struct operation_group_header ogh;  ///< wire operation group header
@@ -113,6 +133,10 @@ struct nexttype_subparser_state {
 
         // Required to read Reveal public key
         union public_key pk;  ///< wire public key
+
+#ifndef TARGET_NANOS
+        struct bls_signature bls_s;  ///< wire BLS signature
+#endif
 
         uint8_t raw[1];  ///< raw array to fill the body
     } body;

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,5 +1,6 @@
 base58
 bip32
 GitPython
-pytezos==3.11.3
-ragger>=1.18.1
+secp256k1
+pytezos==3.13.5
+ragger==1.24.0

--- a/test/test_instructions.py
+++ b/test/test_instructions.py
@@ -1313,9 +1313,13 @@ def test_sign_reveal(
         test_hwm=Hwm(0, 0)
     )
 
+    proof = Default.BLS_SIGNATURE if account.sig_scheme == SigScheme.BLS \
+        else None
+
     reveal = Reveal(
         public_key=account.public_key,
         source=account.public_key_hash,
+        proof=proof,
     )
 
     if not with_hash:


### PR DESCRIPTION
This PR, according to the changes made in the protocol Seoul:
 - adds the `proof` field to the reveal operation
